### PR TITLE
Customize Postgres PVC storage class

### DIFF
--- a/helm-chart/templates/1-db.yaml
+++ b/helm-chart/templates/1-db.yaml
@@ -5,11 +5,14 @@ metadata:
     app: db-data
   name: {{ .Values.postgres.name }}
 spec:
+  {{- if hasKey .Values.postgres "storageClass" }}
+  storageClassName: {{ .Values.postgres.storageClass }}
+  {{- end }}  
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.postgres.storageSize | default "100Mi" }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm-chart/templates/2-core.yaml
+++ b/helm-chart/templates/2-core.yaml
@@ -14,6 +14,22 @@ spec:
       labels:
         app: core
     spec:
+{{- if .Values.core.tolerations }}
+      tolerations:
+  {{- range $toleration := .Values.core.tolerations }}
+        - key: {{ $toleration.key | quote }}
+          operator: {{ $toleration.operator | quote }}
+    {{- if $toleration.value }}
+          value: {{ $toleration.value | quote }}
+    {{- end }}
+    {{- if $toleration.effect }}
+          effect: {{ $toleration.effect | quote }}
+    {{- end }}
+    {{- if $toleration.tolerationSeconds }}
+          tolerationSeconds: {{ $toleration.tolerationSeconds }}
+    {{- end }}
+  {{- end }}
+{{- end }}
       containers:
         - env:
             - name: ML_PORT

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -13,6 +13,8 @@ postgres:
   db_password: postgres
   db_user: postgres
   name: cf-db-data
+  # storageClass: your-storage-class
+  # storageSize: 100Mi
 
 core:
   repository: exadel/compreface-core


### PR DESCRIPTION
These changes allow:

-  select a storage class other than the clusters default storage class
-  provision a specific size for the PVC